### PR TITLE
Send notifications directly to the room, without listing rooms 

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -6,7 +6,7 @@ Capistrano::Configuration.instance(:must_exist).load do
 
   namespace :hipchat do
     task :set_client do
-      set :hipchat_client, HipChat::Client.new(hipchat_token)
+      set :hipchat_client, HipChat::Room.new(hipchat_token, :room_id => hipchat_room_name)
     end
 
     task :trigger_notification do
@@ -20,7 +20,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     task :notify_deploy_started do
       if hipchat_send_notification
         on_rollback do
-          hipchat_client[hipchat_room_name].
+          hipchat_client.
             send(deploy_user, "#{human} cancelled deployment of #{application} to #{env}.", hipchat_announce)
         end
 
@@ -28,13 +28,13 @@ Capistrano::Configuration.instance(:must_exist).load do
         message << " (with migrations)" if hipchat_with_migrations
         message << "."
 
-        hipchat_client[hipchat_room_name].
+        hipchat_client.
           send(deploy_user, message, hipchat_announce)
       end
     end
 
     task :notify_deploy_finished do
-      hipchat_client[hipchat_room_name].
+      hipchat_client.
         send(deploy_user, "#{human} finished deploying #{application} to #{env}.", hipchat_announce)
     end
 


### PR DESCRIPTION
The main reasons of thins change are
- Listing rooms affects performance: +1 request, not much thought :zzz:
- Listing rooms is not available for notification tokens
- Adding token with listing room permission in public(accessible by all participants) it way insecure 

May fix https://github.com/mojotech/hipchat/issues/2 or at least can be used as a workaround
