### PR TITLE
Calling hipchat send 'properly' to avoid deprecation warnings.

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -28,14 +28,22 @@ Capistrano::Configuration.instance(:must_exist).load do
         message << " (with migrations)" if hipchat_with_migrations
         message << "."
 
-        hipchat_client[hipchat_room_name].
-          send(deploy_user, message, hipchat_announce)
+        begin
+          hipchat_client[hipchat_room_name].
+            send(deploy_user, message, hipchat_announce)
+        rescue HipChat::UnknownResponseCode => e
+          puts "***** HipChat is broken, no message sent to chat."
+        end
       end
     end
 
     task :notify_deploy_finished do
-      hipchat_client[hipchat_room_name].
-        send(deploy_user, "#{human} finished deploying #{deployment_name} to #{env}.", :notify => hipchat_announce)
+      begin
+        hipchat_client[hipchat_room_name].
+          send(deploy_user, "#{human} finished deploying #{deployment_name} to #{env}.", :notify => hipchat_announce)
+      rescue HipChat::UnknownResponseCode => e
+        puts "***** HipChat is broken, no message sent to chat."
+      end
     end
 
     def deployment_name


### PR DESCRIPTION
This avoids deprecation warnings on how the 'notify' option is passed.
