### PR TITLE
add server names to Hipchat deployment notifications

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -21,10 +21,10 @@ Capistrano::Configuration.instance(:must_exist).load do
       if hipchat_send_notification
         on_rollback do
           hipchat_client[hipchat_room_name].
-            send(deploy_user, "#{human} cancelled deployment of #{deployment_name} to #{env}.", hipchat_announce)
+            send(deploy_user, "#{human} cancelled deployment of #{deployment_name} to #{env} #{server_names}.", hipchat_announce)
         end
 
-        message = "#{human} is deploying #{deployment_name} to #{env}"
+        message = "#{human} is deploying #{deployment_name} to #{env} #{server_names}"
         message << " (with migrations)" if hipchat_with_migrations
         message << "."
 
@@ -35,7 +35,7 @@ Capistrano::Configuration.instance(:must_exist).load do
 
     task :notify_deploy_finished do
       hipchat_client[hipchat_room_name].
-        send(deploy_user, "#{human} finished deploying #{deployment_name} to #{env}.", hipchat_announce)
+        send(deploy_user, "#{human} finished deploying #{deployment_name} to #{env} #{server_names}.", hipchat_announce)
     end
 
     def deployment_name
@@ -45,7 +45,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         application
       end
     end
-    
+
     def deploy_user
       fetch(:hipchat_deploy_user, "Deploy")
     end
@@ -65,6 +65,11 @@ Capistrano::Configuration.instance(:must_exist).load do
     def env
       fetch(:hipchat_env, fetch(:rack_env, fetch(:rails_env, "production")))
     end
+
+    def server_names
+      "(#{find_servers.join(", ")})"
+    end
+
   end
 
   before "hipchat:notify_deploy_started", "hipchat:set_client"


### PR DESCRIPTION
We love the Capistrano integration, but we often use HOSTFILTER when deploying, so it would be nice to know exactly which servers the notification applies to.  Thanks.
