### PR TITLE
Update README to reflect current Engine Yard deployment architecture.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -52,13 +52,12 @@ Use a "deploy hook":http://bit.ly/qnbIkP to send messages from Engine Yard's Clo
 RAILS_ROOT/deploy/after_restart.rb:
 
 bc.. on_app_master do
-  message  = "Deploying revision #{@configuration[:revision][0...6]}"
-  message += " to #{@configuration[:environment]}"
+  message  = "Deploying revision #{revision[0...6]} to #{node[:environment][:name]}"
   message += " (with migrations)" if migrate?
   message += "."
 
   # Send a message via rake task assuming a hipchat.yml in your config like above
-  run "cd #{release_path} && rake hipchat:send MESSAGE='#{message}'"
+  run "cd #{release_path} && bundle exec rake hipchat:send MESSAGE='#{message}'"
 end
 
 h2. Copyright


### PR DESCRIPTION
- `revision` var now returns revision being deployed.
- Use `node[:environment][:name]` instead of `@configuration[:environment]` or even just `environment` as it's common practice to assign the "production" framework environment to testing and staging servers.
- Rake is not available at the command line so use `bundle exec` to execute it in the app's `Gemset` context.
