### PR TITLE
No way to set user from config file for rake task on most operating systems

### DIFF
--- a/lib/hipchat/rails3_tasks.rb
+++ b/lib/hipchat/rails3_tasks.rb
@@ -8,15 +8,21 @@ namespace :hipchat do
 
     options = {
       :message => ENV['MESSAGE'],
-      :user    => ENV['USER'],
+      :user    => ENV['HIPCHAT_USER'],
       :notify  => ENV['NOTIFY'],
       :room    => ENV['ROOM'],
       :token   => ENV['TOKEN']
+    }.reject { |k, v| v.blank? }
+    
+    system_options = {
+      :user    => ENV['USER']
     }.reject { |k, v| v.blank? }
 
     if File.exists? config_file
       options.reverse_merge! YAML.load_file(config_file).symbolize_keys
     end
+    
+    options.reverse_merge! system_options
 
     options[:notify] = options[:notify].to_s != 'false'
 


### PR DESCRIPTION
Just as in Capistrano, the Linux/Unix/Posix `USER` environment var should be the last resort in determining HipChat user's name in the rake task. As this variable exists on most systems, the config example in the README doesn't hold true as the `user` option is always overridden with the `USER` environment var. Instead, `HIPCHAT_USER` can be used for overriding the config file and `USER` can be used as a last resort.
