### PR TITLE
rake task needs environment variables to be set

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -36,7 +36,7 @@ h2. Rails 3 Rake Task
 
 Send a message using a rake task:
 
-bc.. rake hipchat:send["hello world"]
+bc.. rake hipchat:send MESSAGE="hello world"
 
 Options like the room, API token, user name and notification flag can be set in YAML.
 


### PR DESCRIPTION
The rake tasks syntax doesn't work as proposed. Changed to environment variables.
