### PR TITLE
Avoid HipChat message restrictions by converting all applicable characte...

### DIFF
--- a/lib/hipchat.rb
+++ b/lib/hipchat.rb
@@ -73,7 +73,7 @@ module HipChat
         :body  => {
           :room_id => room_id,
           :from    => from,
-          :message => message,
+          :message => CGI.escapeHTML(message),
           :color   => options[:color],
           :notify  => options[:notify] ? 1 : 0
         }


### PR DESCRIPTION
...rs to HTML entities.

I found this limitation when trying to post a message with the format `User Name <email@something.com>`.
This simple patch fixes that.
