### PR TITLE
Uses hipchat success color in Capistrano

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -35,7 +35,8 @@ bc.. require 'hipchat/capistrano'
 set :hipchat_token, "<your token>"
 set :hipchat_room_name, "Your room" # If you pass an array such as ["room_a", "room_b"] you can send announcements to multiple rooms.
 set :hipchat_announce, false # notify users
-set :hipchat_color, 'green' #finished deployment message color
+set :hipchat_color, 'yellow' #normal message color
+set :hipchat_success_color, 'green' #finished deployment message color
 set :hipchat_failed_color, 'red' #cancelled deployment message color
 set :hipchat_message_format, 'text' # Sets the deployment message format, see https://www.hipchat.com/docs/api/method/rooms/message
 

--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -25,6 +25,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
 
     task :notify_deploy_finished do
+      send_options.merge!(:color => success_message_color)
       send("#{human} finished deploying #{deployment_name} to #{env}#{fetch(:hipchat_with_migrations, '')}.", send_options)
     end
 
@@ -62,6 +63,10 @@ Capistrano::Configuration.instance(:must_exist).load do
 
     def message_color
       fetch(:hipchat_color, nil)
+    end
+
+    def success_message_color
+      fetch(:hipchat_success_color, "green")
     end
 
     def failed_message_color


### PR DESCRIPTION
Allows the user to set the success color during capistrano deployment.
