### PR TITLE
Show revision being deployed by Capistrano

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -55,7 +55,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     def deployment_name
       if branch
         name = "#{application}/#{branch}"
-        name += " (revision #{current_revision[0..7]})" if current_revision
+        name += " (revision #{real_revision[0..7]})" if real_revision
         name
       else
         application


### PR DESCRIPTION
Most of the time it is important to know which revision is being deployed. 
