### PR TITLE
don't blow up if branch isn't specified

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -54,7 +54,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
 
     def deployment_name
-      if branch
+      if fetch(:branch, nil)
         name = "#{application}/#{branch}"
         name += " (revision #{real_revision[0..7]})" if real_revision
         name


### PR DESCRIPTION
we don't have a default branch specified, so the deployment_name
function blows up when it checks for the existence of the `branch`
variable. used fetch to fix that.
