### PR TITLE
Raise an error if the username exceeds the character limit

### DIFF
--- a/lib/hipchat.rb
+++ b/lib/hipchat.rb
@@ -7,6 +7,7 @@ module HipChat
   class UnknownRoom         < StandardError; end
   class Unauthorized        < StandardError; end
   class UnknownResponseCode < StandardError; end
+  class UsernameTooLong < StandardError; end
 
   class Client
     include HTTParty
@@ -59,6 +60,9 @@ module HipChat
     # +notify+:: true or false
     #            (default false)
     def send(from, message, options_or_notify = {})
+      if from.length > 15
+        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 15'"
+      end
       options = if options_or_notify == true or options_or_notify == false
         warn "DEPRECATED: Specify notify flag as an option (e.g., :notify => true)"
         { :notify => options_or_notify }

--- a/spec/hipchat_spec.rb
+++ b/spec/hipchat_spec.rb
@@ -111,6 +111,10 @@ describe HipChat do
       lambda { room.send "", "" }.should raise_error(HipChat::Unauthorized)
     end
 
+    it "but fails if the username is more than 15 chars" do
+      lambda { room.send "a very long username here", "a message" }.should raise_error(HipChat::UsernameTooLong)
+    end
+
     it "but fails if we get an unknown response code" do
       mock(HipChat::Room).post(anything, anything) {
         OpenStruct.new(:code => 403)


### PR DESCRIPTION
the api returns a HTTP 400 error code, if the username is more than 15 chars. This is rather uninformative. 

This change ensures this is checked before sending the request, and that the caller gets an indication how to rectify the problem.
