### PR TITLE
Fix rescue exceptions in capistrano integration

### DIFF
--- a/lib/hipchat/capistrano.rb
+++ b/lib/hipchat/capistrano.rb
@@ -65,13 +65,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       rooms.each { |room|
         begin
           hipchat_client[room].send(deploy_user, message, options)
-        rescue UnknownRoom => e
-          puts e.message
-          puts e.backtrace
-        rescue Unauthorized => e
-          puts e.message
-          puts e.backtrace
-        rescue UnknownResponseCode => e
+        rescue => e
           puts e.message
           puts e.backtrace
         end


### PR DESCRIPTION
When I set invalid color to `hipchat_color` like below, I got `NameError`

```
# deploy.rb
set :hipchat_color,          'invalid-color'
```

```
$ cap deploy
...
* 2013-07-16 11:51:58 executing `hipchat:notify_deploy_finished'
/Users/fukayatsu/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/hipchat-0.10.1/lib/hipchat/capistrano.rb:68:in `rescue in block in send': uninitialized constant UnknownRoom (NameError)
    from /Users/fukayatsu/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/hipchat-0.10.1/lib/hipchat/capistrano.rb:66:in `block in send'
    from /Users/fukayatsu/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/hipchat-0.10.1/lib/hipchat/capistrano.rb:65:in `each'
    from /Users/fukayatsu/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/hipchat-0.10.1/lib/hipchat/capistrano.rb:65:in `send'
    from /Users/fukayatsu/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/hipchat-0.10.1/lib/hipchat/capistrano.rb:42:in `block (3 levels) in <top (required)>'
    ...
```
