### PR TITLE
Chef tweaks

### DIFF
--- a/lib/hipchat/chef.rb
+++ b/lib/hipchat/chef.rb
@@ -15,27 +15,30 @@ require 'hipchat'
 module HipChat
   class NotifyRoom < Chef::Handler
 
-    def initialize(api_token, room_name, notify_users=false, report_success=false)
+    def initialize(api_token, room_name, excluded_envs=[], notify_users=false, report_success=false)
       @api_token = api_token
       @room_name = room_name
+      @excluded_envs = excluded_envs
       @notify_users = notify_users
       @report_success = report_success
     end
 
     def report
-      msg = if run_status.failed? then "Failure on \"#{node.name}\": #{run_status.formatted_exception}"
-            elsif run_status.success? && @report_success
-              "Chef run on \"#{node.name}\" completed in #{run_status.elapsed_time.round(2)} seconds"
-            else nil
-            end
-
-      color = if run_status.success? then 'green'
-              else 'red'
+      unless excluded_envs.include?(node.chef_environment)
+        msg = if run_status.failed? then "Failure on \"#{node.name}\" (\"#{node.chef_environment}\" env): #{run_status.formatted_exception}"
+              elsif run_status.success? && @report_success
+                "Chef run on \"#{node.name}\" completed in #{run_status.elapsed_time.round(2)} seconds"
+              else nil
               end
 
-      if msg
-        client = HipChat::Client.new(@api_token)
-        client[@room_name].send('Chef', msg, :notify => @notify_users, :color => color)
+        color = if run_status.success? then 'green'
+                else 'red'
+                end
+
+        if msg
+          client = HipChat::Client.new(@api_token)
+          client[@room_name].send('Chef', msg, :notify => @notify_users, :color => color)
+        end
       end
     end
   end


### PR DESCRIPTION
It would be great to be able to exclude directly some Chef environments from reporting as well as outputting the `node.chef_environment` in the report.
