### PR TITLE
Adding namespaces to hipchat.rake before and after hooks

### DIFF
--- a/lib/hipchat/capistrano/tasks/hipchat.rake
+++ b/lib/hipchat/capistrano/tasks/hipchat.rake
@@ -102,10 +102,10 @@ namespace :hipchat do
     fetch(:hipchat_env, fetch(:rack_env, fetch(:rails_env, fetch(:stage))))
   end
 
-  before 'deploy:starting', :notify_deploy_started
-  after 'deploy:finished', :notify_deploy_finished
+  before 'deploy:starting', 'hipchat:notify_deploy_started'
+  after 'deploy:finished', 'hipchat:notify_deploy_finished'
   if Rake::Task.task_defined? 'deploy:failed'
-    after 'deploy:failed', :notify_deploy_reverted
+    after 'deploy:failed', 'hipchat:notify_deploy_reverted'
   end
 
 end


### PR DESCRIPTION
When #58 was merged, it removed the name spacing from the `before` and `after` hooks. With the below changes, my alerts work again. Without it, I get the message:

```
$ bundle exec cap integration deploy --trace
** Invoke integration (first_time)
** Execute integration
** Invoke load:defaults (first_time)
** Execute load:defaults
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
** Invoke bundler:map_bins (first_time)
** Execute bundler:map_bins
** Invoke deploy (first_time)
** Execute deploy
** Invoke deploy:starting (first_time)
cap aborted!
Don't know how to build task 'notify_deploy_started'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task_manager.rb:49:in `[]'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:53:in `lookup_prerequisite'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:49:in `block in prerequisite_tasks'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:49:in `map'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:49:in `prerequisite_tasks'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:195:in `invoke_prerequisites'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:174:in `block in invoke_with_call_chain'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:168:in `invoke_with_call_chain'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:161:in `invoke'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/dsl.rb:14:in `invoke'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/tasks/framework.rake:64:in `block (2 levels) in <top (required)>'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/tasks/framework.rake:60:in `each'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/tasks/framework.rake:60:in `block in <top (required)>'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:236:in `call'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:236:in `block in execute'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:231:in `each'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:231:in `execute'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:175:in `block in invoke_with_call_chain'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:168:in `invoke_with_call_chain'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:161:in `invoke'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:149:in `invoke_task'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:106:in `each'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:106:in `block in top_level'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:115:in `run_with_threads'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:100:in `top_level'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:78:in `block in run'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:165:in `standard_exception_handling'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:75:in `run'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/application.rb:12:in `run'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/bin/cap:3:in `<top (required)>'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/bin/cap:23:in `load'
/Users/kristofer.white/.rbenv/versions/1.9.3-p448/bin/cap:23:in `<main>'
Tasks: TOP => deploy:starting
```
