### PR TITLE
require json in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'hipchat'
 require 'rspec'
 require 'rspec/autorun'
+require 'json'
 require 'webmock/rspec'
 require 'coveralls'
 


### PR DESCRIPTION
When running the tests outside of rake or bundler (for example, during RPM packaging), the tests fail because we don't require the json gem before calling `to_json`.

```
Executing(%check): /bin/sh -e /var/tmp/rpm-tmp.vwpgPn
+ umask 022
+ cd /builddir/build/BUILD
~/build/BUILD/hipchat-1.0.1/usr/share/gems/gems/hipchat-1.0.1 ~/build/BUILD/hipchat-1.0.1
+ cd hipchat-1.0.1
+ pushd ./usr/share/gems/gems/hipchat-1.0.1
+ rspec -Ilib spec
DEPRECATION: RSpec::Core::Configuration#backtrace_clean_patterns is deprecated. Use RSpec::Core::Configuration#backtrace_exclusion_patterns instead. Called from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'.
.......................FFFFFFFFFFF.F..
Failures:
  1) HipChat#topic (API v2) is successful without custom options
     Failure/Error: mock_successful_topic_change("Nice topic")
     NoMethodError:
       undefined method `to_json' for {:room_id=>"Hipchat", :from=>"API", :topic=>"Nice topic"}:Hash
     # ./spec/shared_hipchat.rb:66:in `mock_successful_topic_change'
     # ./spec/hipchat_spec.rb:183:in `block (3 levels) in <top (required)>'
```
