### PR TITLE
Initialize Room class properly, when calling rooms method

### DIFF
--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -44,7 +44,7 @@ module HipChat
       case response.code
       when 200
         response[@api.rooms_config[:data_key]].map do |r|
-          Room.new(@token, r.merge(:api_version => @api_version))
+          Room.new(@token, r.merge(:api_version => @api_version, :room_id => r['id']))
         end
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for room"


### PR DESCRIPTION
We have to pass :room_id hash value to Room.new so then class HipChat::ApiVersion::Room get initialised properly. 
