### PR TITLE
changing users/view to get instead of post

### DIFF
--- a/lib/hipchat/user.rb
+++ b/lib/hipchat/user.rb
@@ -44,19 +44,17 @@ module HipChat
     #
     def view
       puts "#{@api.base_uri}#{@api.view_config[:url]}"
-      response = self.class.post(@api.view_config[:url],
+      response = self.class.get(@api.view_config[:url],
         :query => { :auth_token => @token },
         :headers => @api.headers
       )
 
       case response.code
       when 200
-        response[@api.users_config[:data_key]].map do |r|
-          User.new(@token, r.merge(:api_version => @api_version))
-        end
+          User.new(@token, response.merge(:api_version => 'v2'))
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for view message to `#{user_id}'"
       end
     end
   end
-end
+end 


### PR DESCRIPTION
Hello :)

When trying to use User.view, I get a 405 response form hipchat. The [api documentation](https://www.hipchat.com/docs/apiv2/method/view_user) states that this is a get, so this is one of the changes. 

Another change is to expect a scalar as a result, instead of an array of results. Also, **users_config** is not inside HipChat::ApiVersion::User (and the api version is also not stored there), but in any case, since api v1 is not allowed to use this method, 'v2' is merged in the results. I hope this is ok, it sounds like the minimum viable change to do.

Cheers!
