### PR TITLE
Fixed README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -20,7 +20,7 @@ bc.. client = HipChat::Client.new(api_token)
 client['my room'].send('username', 'I talk')
 
 # Send notifications to users (default false)
-client['my room'].send('username', 'I quit!', :notify => 1)
+client['my room'].send('username', 'I quit!', :notify => true)
 
 # Color it red. or "yellow", "green", "purple", "random" (default "yellow")
 client['my room'].send('username', 'Build failed!', :color => 'red')


### PR DESCRIPTION
Usage API v1 changed 154256550d0f539aea4a10b4c668c537c9f31f5b use `@api.bool_val`
Now, v1 notify option set `1` mean `true`, `0` mean `true` :cry: 
