### PR TITLE
Fix client.rooms to set room's server_url correctly

### DIFF
--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -86,7 +86,7 @@ module HipChat
       case response.code
       when 200
         response[@api.rooms_config[:data_key]].map do |r|
-          Room.new(@token, r.merge(:api_version => @api_version, :room_id => r['id']))
+          Room.new(@token, r.merge(:api_version => @api_version, :room_id => r['id'], :server_url => @options[:server_url]))
         end
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for room"

--- a/spec/hipchat_api_v1_spec.rb
+++ b/spec/hipchat_api_v1_spec.rb
@@ -19,6 +19,14 @@ describe "HipChat (API V1)" do
       room.history(:timezone => 'America/Los_Angeles', :date => '2010-11-19').should be_true
     end
 
+    it "is successful from fetched room" do
+      mock_successfull_rooms
+      mock_successful_history
+
+      subject.rooms.should be_true
+      subject.rooms.first.history.should be_true
+    end
+
     it "fails when the room doen't exist" do
       mock(HipChat::Room).get(anything, anything) {
         OpenStruct.new(:code => 404)

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -20,6 +20,14 @@ describe "HipChat (API V2)" do
       room.history(:timezone => 'America/Los_Angeles', :date => '2010-11-19').should be_true
     end
 
+    it "is successful from fetched room" do
+      mock_successfull_rooms
+      mock_successful_history
+
+      subject.rooms.should be_true
+      subject.rooms.first.history.should be_true
+    end
+
     it "fails when the room doen't exist" do
       mock(HipChat::Room).get(anything, anything) {
         OpenStruct.new(:code => 404)

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -29,6 +29,17 @@ shared_context "HipChatV1" do
                                           'Content-Type' => 'application/x-www-form-urlencoded'}).to_return(:status => 200, :body => "", :headers => {})
   end
 
+  def mock_successfull_rooms
+    stub_request(:get, "https://api.hipchat.com/v1/rooms/list").with(
+                             :query => {:auth_token => "blah"},
+                             :body => "",
+                             :headers => {'Accept' => 'application/json',
+                                          'Content-Type' => 'application/x-www-form-urlencoded'}).to_return(
+                                            :status => 200,
+                                            :body => '{"rooms":[{"id": "Hipchat", "links": {"self": "https://api.hipchat.com/v2/room/12345"}}]}',
+                                            :headers => {})
+  end
+
   def mock_successful_history(options={})
     options = { :date => 'recent', :timezone => 'UTC', :format => 'JSON' }.merge(options)
     canned_response = File.new(HISTORY_JSON_PATH)
@@ -78,6 +89,17 @@ shared_context "HipChatV2" do
                                         :topic   => "Nice topic" }.to_json,
                                         :headers => {'Accept' => 'application/json',
                                                     'Content-Type' => 'application/json'}).to_return(:status => 200, :body => "", :headers => {})
+  end
+
+  def mock_successfull_rooms
+    stub_request(:get, "https://api.hipchat.com/v2/room").with(
+                             :query => {:auth_token => "blah"},
+                             :body => "",
+                             :headers => {'Accept' => 'application/json',
+                                          'Content-Type' => 'application/json'}).to_return(
+                                            :status => 200,
+                                            :body => '{"items":[{"id": "Hipchat", "links": {"self": "https://api.hipchat.com/v2/room/12345"}}]}',
+                                            :headers => {})
   end
 
   def mock_successful_history(options={})


### PR DESCRIPTION
If try to fetch room's history through fetched rooms object like

```
client.rooms.find {|room| room.name =~ /Hipchat/ }.history
```

fails with

```
URI::InvalidURIError: the scheme http does not accept registry part: :80 (or bad hostname?)
```

This is because `HipChat::Room.base_uri` is not set at `HipChat::Room#initialize`.

This commit fix above issue.
