### PR TITLE
allow options for chef notifier

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -209,8 +209,11 @@ end
 h2. Chef Handler
 
 *APIv1 ONLY, use APIv1 Key*
+NOTE: APIv2 required for HipChatServer Beta
 
-Report on Chef runs. Within a Recipe:
+Report on Chef runs. 
+
+h3. Within a Recipe:
 
 bc.. include_recipe 'chef_handler'
 
@@ -222,6 +225,18 @@ chef_handler 'HipChat::NotifyRoom' do
   source File.join(Gem.all_load_paths.grep(/hipchat/).first,
                    'hipchat', 'chef.rb')
 end
+
+h3. With client.rb:
+
+bc..    require 'hipchat/chef'
+   hipchat_handler = HipChat::NotifyRoom.new("API_KEY", "HIPCHAT_ROOM")
+   exception_handlers << hipchat_handler
+
+h3. With HipChat Server Beta
+
+Add an "options" hash to set api v2 and your URL:
+* arguments ['API_KEY', 'HIPCHAT_ROOM', options={api_version: "v2", server_url: "https://hipchat.example.com"}]
+* hipchat_handler = HipChat::NotifyRoom.new("API_KEY", "HIPCHAT_ROOM", options={api_version: "v2", server_url: "https://hipchat.example.com"})
 
 h2. Copyright
 

--- a/lib/hipchat/chef.rb
+++ b/lib/hipchat/chef.rb
@@ -15,9 +15,10 @@ require 'hipchat'
 module HipChat
   class NotifyRoom < Chef::Handler
 
-    def initialize(api_token, room_name, notify_users=false, report_success=false, excluded_envs=[])
+    def initialize(api_token, room_name, options={}, notify_users=false, report_success=false, excluded_envs=[])
       @api_token = api_token
       @room_name = room_name
+      @options = options
       @notify_users = notify_users
       @report_success = report_success
       @excluded_envs = excluded_envs
@@ -36,7 +37,7 @@ module HipChat
                 end
 
         if msg
-          client = HipChat::Client.new(@api_token)
+          client = HipChat::Client.new(@api_token, @options)
           client[@room_name].send('Chef', msg, :notify => @notify_users, :color => color)
         end
       end


### PR DESCRIPTION
This will pass along options for api_version, server_url etc if they are
set. This allows sending notifications from chef-client to HipChat
Server Beta systems.
