### PR TITLE
tests: make coveralls optional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,13 @@ require 'rspec'
 require 'rspec/autorun'
 require 'json'
 require 'webmock/rspec'
-require 'coveralls'
 
-Coveralls.wear!
+begin
+  require 'coveralls'
+  Coveralls.wear!
+rescue LoadError
+  warn 'warning: coveralls gem not found; skipping coverage'
+end
 
 Dir["./spec/support/**/*.rb"].each {|f| require f}
 


### PR DESCRIPTION
If we do not have Coveralls installed, we should be able to continue with the rest of the test suite.

This allows the tests to run outside of Bundler if Coveralls is not installed.
