### PR TITLE
bugfix: added missing server_url parameter

### DIFF
--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -113,7 +113,7 @@ module HipChat
       case response.code
       when 200
         response[@api.users_config[:data_key]].map do |u|
-          HipChat::User.new(@token, u.merge(:api_version => @api_version))
+          HipChat::User.new(@token, u.merge(:api_version => @api_version, :server_url => @options[:server_url]))
         end
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for user"


### PR DESCRIPTION
I could not send PM to others on my own hosted HipChat server without this patch.