### PR TITLE
Send call wasn't being passed the room name properly

### DIFF
--- a/lib/hipchat/rails3_tasks.rb
+++ b/lib/hipchat/rails3_tasks.rb
@@ -42,8 +42,8 @@ namespace :hipchat do
 
     client = HipChat::Client.new(options[:token], options)
 
-    options[:room].each do |r| 
-      client[options[r]].send(options[:user], options[:message], { :color => options[:color], :notify => options[:notify] })
+    options[:room].each do |r|
+      client[r].send(options[:user], options[:message], { :color => options[:color], :notify => options[:notify] })
     end
   end
 end


### PR DESCRIPTION
When running the rake task I would get the error:
```
$ rake hipchat:send MESSAGE="hello world"
rake aborted!
HipChat::UnknownResponseCode: Unexpected 405 for room `'
```

This change fixed the issue for me.