### PR TITLE
Revert 86302c9e, fixes #131, reverts #107

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -154,6 +154,7 @@ bc.. # Required
 set :hipchat_token, "<your token>"
 set :hipchat_room_name, "Your room" # If you pass an array such as ["room_a", "room_b"] you can send announcements to multiple rooms.
 # Optional
+set :hipchat_enabled, true # set to false to prevent any messages from being sent
 set :hipchat_announce, false # notify users
 set :hipchat_color, 'yellow' #normal message color
 set :hipchat_success_color, 'green' #finished deployment message color

--- a/lib/hipchat/capistrano/tasks/hipchat.rake
+++ b/lib/hipchat/capistrano/tasks/hipchat.rake
@@ -25,8 +25,6 @@ namespace :hipchat do
   end
 
   def send_message(message, options)
-    return unless options[:notify]
-
     hipchat_token = fetch(:hipchat_token)
     hipchat_room_name = fetch(:hipchat_room_name)
     hipchat_options = fetch(:hipchat_options, {})

--- a/lib/hipchat/capistrano/tasks/hipchat.rake
+++ b/lib/hipchat/capistrano/tasks/hipchat.rake
@@ -25,6 +25,8 @@ namespace :hipchat do
   end
 
   def send_message(message, options)
+    return unless enabled?
+
     hipchat_token = fetch(:hipchat_token)
     hipchat_room_name = fetch(:hipchat_room_name)
     hipchat_options = fetch(:hipchat_options, {})
@@ -47,6 +49,10 @@ namespace :hipchat do
         puts e.backtrace
       end
     }
+  end
+
+  def enabled?
+    fetch(:hipchat_enabled, true)
   end
 
   def environment_string

--- a/lib/hipchat/capistrano2.rb
+++ b/lib/hipchat/capistrano2.rb
@@ -58,6 +58,8 @@ Capistrano::Configuration.instance(:must_exist).load do
     end
 
     def send(message, options)
+      return unless enabled?
+
       hipchat_options = fetch(:hipchat_options, {})
       set :hipchat_client, HipChat::Client.new(hipchat_token, hipchat_options) if fetch(:hipchat_client, nil).nil?
 
@@ -77,6 +79,10 @@ Capistrano::Configuration.instance(:must_exist).load do
           puts e.backtrace
         end
       }
+    end
+
+    def enabled?
+      fetch(:hipchat_enabled, true)
     end
 
     def deployment_name


### PR DESCRIPTION
hipchat_announce (while not a great name) is currently used to enable
user-notification of messages, not whether or not the task should send
any messages at all.

I've introduced :hipchat_enabled as an alternative to preserve the intent of #107 -- the ability to disable message sending entirely.

See https://www.hipchat.com/docs/apiv2/method/send_room_notification