### PR TITLE
Adds `color` to the hipchat.yml example for rake task.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -202,6 +202,7 @@ room: ["Room name(s) or id(s)"] # this is an array
 user: "Your name" # Default to `whoami`
 notify: true # Defaults to false
 api_version: "v2" # optional, defaults to v1
+color: "yellow"
 
 h2. Engine Yard
 


### PR DESCRIPTION
Hey everyone,

When updating the hipchat gem (we use it in our deploy hooks), I started getting an error with the rake task.

```
HipChat::UnknownResponseCode: Unexpected 400 for room `<room>`
```

It looks like it was happening because the `color` option was being passed as nil (if you don't provide it in hipchat.yml). Per the API docs (https://www.hipchat.com/docs/apiv2/method/send_room_notification), color is optional; but in this case, the rake task always tries to pass it.

Simply adding `color` to the README might help people in the future.