### PR TITLE
fix user and room send_file

### DIFF
--- a/lib/hipchat/file_helper.rb
+++ b/lib/hipchat/file_helper.rb
@@ -22,7 +22,7 @@ module HipChat
       body << ''
       body << message
       body << "--#{BOUNDARY}"
-      body << "Content-Type: #{mime_type}; charset=UTF-8"
+      body << "Content-Type: #{mime_type}"
       body << 'Content-Transfer-Encoding: base64'
       body << %{Content-Disposition: attachment; name="file"; filename="#{file_name}"}
       body << ''

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -85,7 +85,7 @@ shared_context "HipChatV2" do
   def mock_successful_file_send(from, message, file)
     stub_request(:post, "https://api.hipchat.com/v2/room/Hipchat/share/file").with(
                              :query => {:auth_token => "blah"},
-                             :body  => "--sendfileboundary\nContent-Type: application/json; charset=UTF-8\nContent-Disposition: attachment; name=\"metadata\"\n\n{\"room_id\":\"Hipchat\",\"from\":\"Dude\",\"message\":\"Hello world\"}\n--sendfileboundary\nContent-Type: ; charset=UTF-8\nContent-Transfer-Encoding: base64\nContent-Disposition: attachment; name=\"file\"; filename=\"#{File.basename(file.path)}\"\n\ndGhlIGNvbnRlbnQ=\n\n--sendfileboundary--",
+                             :body  => "--sendfileboundary\nContent-Type: application/json; charset=UTF-8\nContent-Disposition: attachment; name=\"metadata\"\n\n{\"room_id\":\"Hipchat\",\"from\":\"Dude\",\"message\":\"Hello world\"}\n--sendfileboundary\nContent-Type: \nContent-Transfer-Encoding: base64\nContent-Disposition: attachment; name=\"file\"; filename=\"#{File.basename(file.path)}\"\n\ndGhlIGNvbnRlbnQ=\n\n--sendfileboundary--",
                              :headers => {'Accept' => 'application/json',
                                           'Content-Type' => 'multipart/related; boundary=sendfileboundary'}).to_return(:status => 200, :body => "", :headers => {})
   end
@@ -206,7 +206,7 @@ shared_context "HipChatV2" do
   def mock_successful_user_send_file(message, file)
     stub_request(:post, "https://api.hipchat.com/v2/user/12345678/share/file").with(
                                    :query   => {:auth_token => "blah"},
-                                   :body    => "--sendfileboundary\nContent-Type: application/json; charset=UTF-8\nContent-Disposition: attachment; name=\"metadata\"\n\n{\"message\":\"Equal bytes for everyone\"}\n--sendfileboundary\nContent-Type: ; charset=UTF-8\nContent-Transfer-Encoding: base64\nContent-Disposition: attachment; name=\"file\"; filename=\"#{File.basename(file)}\"\n\ndGhlIGNvbnRlbnQ=\n\n--sendfileboundary--",
+                                   :body    => "--sendfileboundary\nContent-Type: application/json; charset=UTF-8\nContent-Disposition: attachment; name=\"metadata\"\n\n{\"message\":\"Equal bytes for everyone\"}\n--sendfileboundary\nContent-Type: \nContent-Transfer-Encoding: base64\nContent-Disposition: attachment; name=\"file\"; filename=\"#{File.basename(file)}\"\n\ndGhlIGNvbnRlbnQ=\n\n--sendfileboundary--",
                                    :headers => {'Accept' => 'application/json',
                                                 'Content-Type' => 'multipart/related; boundary=sendfileboundary'}).to_return(:status => 200, :body => "", :headers => {})
   end


### PR DESCRIPTION
I removed a charset param that is not required by [hipchat api]( https://www.hipchat.com/docs/apiv2/method/share_file_with_room) and, moreover, the api is returning 400 when that charset param is passed.

```
Unsupported encoding: 'UTF-8'. Please, consider using UTF-8. 
```

This PR fix the send_file call by removing that param