### PR TITLE
Use a common parent class for all the errors

### DIFF
--- a/lib/hipchat/errors.rb
+++ b/lib/hipchat/errors.rb
@@ -1,10 +1,11 @@
 module HipChat
-  class UnknownRoom         < StandardError; end
-  class RoomNameTooLong     < StandardError; end
-  class RoomMissingOwnerUserId < StandardError; end
-  class Unauthorized        < StandardError; end
-  class UsernameTooLong     < StandardError; end
-  class UnknownResponseCode < StandardError; end
-  class UnknownUser         < StandardError; end
-  class InvalidApiVersion   < StandardError; end
+  class ServiceError        < StandardError; end
+  class UnknownRoom         < ServiceError; end
+  class RoomNameTooLong     < ServiceError; end
+  class RoomMissingOwnerUserId < ServiceError; end
+  class Unauthorized        < ServiceError; end
+  class UsernameTooLong     < ServiceError; end
+  class UnknownResponseCode < ServiceError; end
+  class UnknownUser         < ServiceError; end
+  class InvalidApiVersion   < ServiceError; end
 end


### PR DESCRIPTION
In the current version of the hipchat gem when you want to deal with
hipchat exceptions you have to list all the possible exceptions that the
library can throw. This PR add a common base class to make rescuing a bit
easier.