### PR TITLE
Handle API rate limit responses with RateLimitExceeded exception

### DIFF
--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -51,6 +51,8 @@ module HipChat
         raise UnknownRoom,  "Error: #{response.message}"
       when 401
         raise Unauthorized, 'Access denied'
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       else
         raise UnknownResponseCode, "Unexpected error #{response.code}"
       end
@@ -97,6 +99,8 @@ module HipChat
         response[@api.rooms_config[:data_key]].map do |r|
           HipChat::Room.new(@token, r.merge(:api_version => @api_version, :server_url => @options[:server_url]))
         end
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for room"
       end
@@ -115,6 +119,8 @@ module HipChat
         response[@api.users_config[:data_key]].map do |u|
           HipChat::User.new(@token, u.merge(:api_version => @api_version, :server_url => @options[:server_url]))
         end
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for user"
       end

--- a/lib/hipchat/errors.rb
+++ b/lib/hipchat/errors.rb
@@ -7,4 +7,5 @@ module HipChat
   class UnknownResponseCode < StandardError; end
   class UnknownUser         < StandardError; end
   class InvalidApiVersion   < StandardError; end
+  class RateLimitExceeded   < StandardError; end
 end

--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -30,6 +30,8 @@ module HipChat
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for room `#{room_id}'"
       end
@@ -59,6 +61,8 @@ module HipChat
       when 200, 204; true
       when 404
         raise Unknown Room, "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -79,6 +83,8 @@ module HipChat
       when 200, 204; true
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -136,6 +142,8 @@ module HipChat
       when 200, 204; true
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -163,6 +171,8 @@ module HipChat
       when 200, 204; true
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -197,6 +207,8 @@ module HipChat
       when 200, 204; true
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -233,6 +245,8 @@ module HipChat
       when 204,200; true
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -283,6 +297,8 @@ module HipChat
         response.body
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else
@@ -309,6 +325,8 @@ module HipChat
         response.body
       when 404
         raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to room `#{room_id}'"
       else

--- a/lib/hipchat/user.rb
+++ b/lib/hipchat/user.rb
@@ -34,6 +34,8 @@ module HipChat
         true
       when 404
         raise UnknownUser, "Unknown user: `#{user_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to user `#{user_id}'"
       else
@@ -55,6 +57,8 @@ module HipChat
       when 200, 204; true
       when 404
         raise UnknownUser,  "Unknown user: `#{user_id}'"
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       when 401
         raise Unauthorized, "Access denied to user `#{user_id}'"
       else
@@ -74,6 +78,8 @@ module HipChat
       case response.code
       when 200
         User.new(@token, response.merge(:api_version => @api.version))
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for view message to `#{user_id}'"
       end
@@ -93,6 +99,8 @@ module HipChat
       case response.code
       when 200
         response.body
+      when 403
+        raise RateLimitExceeded, "API Rate limit exceeded"
       else
         raise UnknownResponseCode, "Unexpected #{response.code} for view private message history for `#{user_id}'"
       end

--- a/spec/hipchat_api_v1_spec.rb
+++ b/spec/hipchat_api_v1_spec.rb
@@ -43,9 +43,17 @@ describe "HipChat (API V1)" do
       expect { room.history }.to raise_error(HipChat::Unauthorized)
     end
 
-    it "fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).get(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      expect { room.history }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "fails if we get an unknown response code" do
+      mock(HipChat::Room).get(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       expect { room.history }.to raise_error(HipChat::UnknownResponseCode)
@@ -82,9 +90,17 @@ describe "HipChat (API V1)" do
       expect { room.topic "" }.to raise_error(HipChat::Unauthorized)
     end
 
-    it "fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).post(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      expect { room.topic "" }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "fails if we get an unknown response code" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       expect { room.topic "" }.to raise_error(HipChat::UnknownResponseCode)
@@ -137,9 +153,17 @@ describe "HipChat (API V1)" do
       expect { room.send "a very long username here", "a message" }.to raise_error(HipChat::UsernameTooLong)
     end
 
-    it "but fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).post(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      expect { room.send "", "" }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "but fails if we get an unknown response code" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       expect { room.send "", "" }.to raise_error(HipChat::UnknownResponseCode)

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -44,9 +44,17 @@ describe "HipChat (API V2)" do
       expect { room.history }.to raise_error(HipChat::Unauthorized)
     end
 
-    it "fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).get(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      expect { room.history }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "fails if we get an unknown response code" do
+      mock(HipChat::Room).get(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       expect { room.history }.to raise_error(HipChat::UnknownResponseCode)
@@ -85,9 +93,17 @@ describe "HipChat (API V2)" do
       expect { room.statistics }.to raise_error(HipChat::Unauthorized)
     end
 
-    it "fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).get(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      expect { room.statistics }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "fails if we get an unknown response code" do
+      mock(HipChat::Room).get(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       expect { room.statistics }.to raise_error(HipChat::UnknownResponseCode)
@@ -124,9 +140,17 @@ describe "HipChat (API V2)" do
       expect { room.topic "" }.to raise_error(HipChat::Unauthorized)
     end
 
+    it "fails when we've hit the API rate limit" do
+      mock(HipChat::Room).put(anything, anything) {
+        OpenStruct.new(:code => 403)
+      }
+
+      expect { room.topic "" }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
     it "fails if we get an unknown response code" do
         mock(HipChat::Room).put(anything, anything) {
-          OpenStruct.new(:code => 403)
+          OpenStruct.new(:code => 407)
         }
 
       expect { room.topic "" }.to raise_error(HipChat::UnknownResponseCode)
@@ -179,9 +203,17 @@ describe "HipChat (API V2)" do
       expect { room.send "a very long username here", "a message" }.to raise_error(HipChat::UsernameTooLong)
     end
 
-    it "but fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).post(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      expect { room.send "", "" }.to raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "but fails if we get an unknown response code" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       expect { room.send "", "" }.to raise_error(HipChat::UnknownResponseCode)
@@ -217,9 +249,18 @@ describe "HipChat (API V2)" do
       lambda { room.share_link "a very long username here", "a message", link }.should raise_error(HipChat::UsernameTooLong)
     end
 
-    it "but fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).post(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      lambda { room.share_link "", "", link }.
+        should raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "but fails if we get an unknown response code" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       lambda { room.share_link "", "", link }.
@@ -265,9 +306,18 @@ describe "HipChat (API V2)" do
       lambda { room.send_file "a very long username here", "a message", file }.should raise_error(HipChat::UsernameTooLong)
     end
 
-    it "but fails if we get an unknown response code" do
+    it "fails when we've hit the API rate limit" do
       mock(HipChat::Room).post(anything, anything) {
         OpenStruct.new(:code => 403)
+      }
+
+      lambda { room.send_file "", "", file }.
+        should raise_error(HipChat::RateLimitExceeded)
+    end
+
+    it "but fails if we get an unknown response code" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 407)
       }
 
       lambda { room.send_file "", "", file }.

--- a/spec/hipchat_spec.rb
+++ b/spec/hipchat_spec.rb
@@ -70,4 +70,3 @@ describe HipChat do
     end
   end
 end
-


### PR DESCRIPTION
This adds a new `RateLimitExceeded` exception when a 403 response code is encountered as described [in the docs](https://www.hipchat.com/docs/api/rate_limiting). I've been hitting this in an on-prem installation and it would be nice to be able to rescue this error. Having some way to fetch the current rate limit values via the Ruby client would be nice too, but that's outside the scope of this PR, I think.

I believe I got all the places where this needed to go and updated the tests accordingly, but would love a once-over by someone more familiar with the code.
