### PR TITLE
Add support for 'add member', 'send message' and 'create user' in user/room API

### DIFF
--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -56,6 +56,19 @@ module HipChat
         }[version]
       end
 
+      def create_user_config
+        {
+          'v1' => {
+            :url => '/users/create',
+            :body_format => :to_hash
+          },
+          'v2' => {
+            :url => '/user',
+            :body_format => :to_json
+          }
+        }[version]
+      end
+
       def users_config
         {
           'v1' => {

--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -134,6 +134,15 @@ module HipChat
         }[version]
       end
 
+      def send_message_config
+        {
+          'v2' => {
+            :url => URI::escape("/#{room_id}/message"),
+            :body_format => :to_json
+          }
+        }[version]
+      end
+
       def send_config
         {
           'v1' => {

--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -276,6 +276,22 @@ module HipChat
         }[version]
       end
 
+
+      def delete_config
+        {
+          'v1' => {
+            :url => URI::escape('/delete'),
+            :body_format => :to_json,
+            :query_params => { :user_id => user_id }
+          },
+          'v2' => {
+            :url => URI::escape("/#{user_id}"),
+            :body_format => :to_json,
+            :query_params => {}
+          }
+        }[version]
+      end
+
       def history_config
         raise InvalidApiVersion, 'This functionality is not supported in API v1' unless version.eql?('v2')
 

--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -125,6 +125,15 @@ module HipChat
         }[version]
       end
 
+      def member_config
+        {
+          'v2' => {
+            :url => URI::escape("/#{room_id}/member"),
+            :body_format => :to_json
+          }
+        }[version]
+      end
+
       def send_config
         {
           'v1' => {

--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -125,7 +125,7 @@ module HipChat
         }[version]
       end
 
-      def member_config
+      def add_member_config
         {
           'v2' => {
             :url => URI::escape("/#{room_id}/member"),

--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -56,6 +56,32 @@ module HipChat
       end
     end
 
+    def create_user(name, email, options={})
+      if name.length > 50
+        raise UsernameTooLong, "User name #{name} is #{name.length} characters long. Limit is 50."
+      end
+
+      response = self.class.post(@api.create_user_config[:url],
+        :query => { :auth_token => @token },
+        :body => {
+          :name => name,
+          :email => email
+          }.merge(options).send(@api.create_user_config[:body_format]),
+        :headers => @api.headers
+      )
+
+      case response.code
+      when 201, 200 #CREATED
+        response.parsed_response
+      when 400
+        raise UnknownUser,  "Error: #{response.message}"
+      when 401
+        raise Unauthorized, 'Access denied'
+      else
+        raise UnknownResponseCode, "Unexpected error #{response.code}"
+      end
+    end
+
     def user(name)
       HipChat::User.new(@token, { :user_id => name, :api_version => @api_version, :server_url => @options[:server_url] })
     end

--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -112,6 +112,35 @@ module HipChat
     # Usage:
     #
     #   # Default
+    #   send 'some message'
+    #
+    def send_message(message)
+      response = self.class.post(@api.send_message_config[:url],
+        :query => { :auth_token => @token },
+        :body  => {
+          :room_id => room_id,
+          :message => message,
+        }.send(@api.send_config[:body_format]),
+        :headers => @api.headers
+      )
+
+      case response.code
+      when 200, 201; true
+      when 404
+        raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 401
+        raise Unauthorized, "Access denied to room `#{room_id}'"
+      else
+        raise UnknownResponseCode, "Unexpected #{response.code} for room `#{room_id}'"
+      end
+    end
+
+
+    # Send a notification message to this room.
+    #
+    # Usage:
+    #
+    #   # Default
     #   send 'nickname', 'some message'
     #
     #   # Notify users and color the message red

--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -87,10 +87,12 @@ module HipChat
     end
 
     # Add member to this room
-    def member(user)
-      response = self.class.put(@api.member_config[:url]+"/#{user}",
+    def add_member(user, room_roles=['room_member'])
+      response = self.class.put(@api.add_member_config[:url]+"/#{user}",
         :query => { :auth_token => @token },
-        :body => {}.to_json,
+        :body => {
+          :room_roles => room_roles
+        }.to_json,
         :headers => @api.headers)
 
       case response.code

--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -86,6 +86,24 @@ module HipChat
       end
     end
 
+    # Add member to this room
+    def member(user)
+      response = self.class.put(@api.member_config[:url]+"/#{user}",
+        :query => { :auth_token => @token },
+        :body => {}.to_json,
+        :headers => @api.headers)
+
+      case response.code
+      when 200, 204; true
+      when 404
+        raise UnknownRoom,  "Unknown room: `#{room_id}'"
+      when 401
+        raise Unauthorized, "Access denied to room `#{room_id}'"
+      else
+        raise UnknownResponseCode, "Unexpected #{response.code} for room `#{room_id}'"
+      end
+    end
+
 
     # Send a message to this room.
     #

--- a/lib/hipchat/user.rb
+++ b/lib/hipchat/user.rb
@@ -97,5 +97,30 @@ module HipChat
         raise UnknownResponseCode, "Unexpected #{response.code} for view private message history for `#{user_id}'"
       end
     end
+
+    #
+    # Get private message history
+    #
+    def delete(params = {})
+      case @api.version
+      when 'v1'
+        response = self.class.post(@api.delete_config[:url],
+                                  :query => { :auth_token => @token }.merge(params),
+                                  :headers => @api.headers
+        )
+      when 'v2'
+        response = self.class.delete(@api.delete_config[:url],
+                                  :query => { :auth_token => @token },
+                                  :headers => @api.headers
+        )
+      end
+
+      case response.code
+      when 200, 204
+        true
+      else
+        raise UnknownResponseCode, "Unexpected #{response.code} for delete user for `#{user_id}'"
+      end
+    end
   end
 end

--- a/spec/hipchat_api_v1_spec.rb
+++ b/spec/hipchat_api_v1_spec.rb
@@ -166,6 +166,27 @@ describe "HipChat (API V1)" do
     end
   end
 
+  describe "#create_user" do
+    include_context "HipChatV1"
+
+    it "successfully with user name" do
+      mock_successful_user_creation("A User", "email@example.com")
+
+      expect(subject.create_user("A User", "email@example.com")).to be_truthy
+    end
+
+    it "successfully with custom parameters" do
+      mock_successful_user_creation("A User", "email@example.com", {:title => "Super user", :password => "password", :is_group_admin => "true"})
+
+      expect(subject.create_user("A User", "email@example.com", {:title => "Super user", :password => "password", :is_group_admin =>true})).to be_truthy
+    end
+
+    it "but fail is name is longer then 50 char" do
+      expect { subject.create_user("A User that is too long that I should fail right now", "email@example.com") }.
+        to raise_error(HipChat::UsernameTooLong)
+    end
+  end
+
   describe "#send user message" do
     it "fails because API V1 doesn't support user operations" do
 

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -341,13 +341,19 @@ describe "HipChat (API V2)" do
     end
   end
 
-  describe "#member" do
+  describe "#add_member" do
     include_context "HipChatV2"
 
     it "successfully with user_id" do
-      mock_successful_member()
+      mock_successful_add_member()
 
-      expect(room.member("1234")).to be_truthy
+      expect(room.add_member("1234")).to be_truthy
+    end
+
+    it "successfully with custom parameters" do
+      mock_successful_add_member({:user_id => "321", :room_roles => ["room_admin","room_member"]})
+
+      expect(room.add_member("321", ["room_admin","room_member"])).to be_truthy
     end
   end
 

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -329,6 +329,27 @@ describe "HipChat (API V2)" do
     end
   end
 
+  describe "#create_user" do
+    include_context "HipChatV2"
+
+    it "successfully with user name" do
+      mock_successful_user_creation("A User", "email@example.com")
+
+      expect(subject.create_user("A User", "email@example.com")).to be_truthy
+    end
+
+    it "successfully with custom parameters" do
+      mock_successful_user_creation("A User", "email@example.com", {:title => "Super user", :password => "password", :is_group_admin => true})
+
+      expect(subject.create_user("A User", "email@example.com", {:title => "Super user", :password => "password", :is_group_admin =>true})).to be_truthy
+    end
+
+    it "but fail is name is longer then 50 char" do
+      expect { subject.create_user("A User that is too long that I should fail right now", "email@example.com") }.
+        to raise_error(HipChat::UsernameTooLong)
+    end
+  end
+
   describe "#get_room" do
     include_context "HipChatV2"
 

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -341,6 +341,16 @@ describe "HipChat (API V2)" do
     end
   end
 
+  describe "#member" do
+    include_context "HipChatV2"
+
+    it "successfully with user_id" do
+      mock_successful_member()
+
+      expect(room.member("1234")).to be_truthy
+    end
+  end
+
   describe "#send user message" do
     include_context "HipChatV2"
     it "successfully with a standard message" do

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -133,6 +133,39 @@ describe "HipChat (API V2)" do
     end
   end
 
+  describe "#send_message" do
+    include_context "HipChatV2"
+    it "successfully without custom options" do
+      mock_successful_send_message 'Hello world'
+
+      expect(room.send_message("Hello world")).to be_truthy
+    end
+
+    it "but fails when the room doesn't exist" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 404)
+      }
+
+      expect { room.send_message "" }.to raise_error(HipChat::UnknownRoom)
+    end
+
+    it "but fails when we're not allowed to do so" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 401)
+      }
+
+      expect { room.send_message "" }.to raise_error(HipChat::Unauthorized)
+    end
+
+    it "but fails if we get an unknown response code" do
+      mock(HipChat::Room).post(anything, anything) {
+        OpenStruct.new(:code => 403)
+      }
+
+      expect { room.send_message "" }.to raise_error(HipChat::UnknownResponseCode)
+    end
+  end
+
   describe "#send" do
     include_context "HipChatV2"
     it "successfully without custom options" do

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -197,6 +197,18 @@ shared_context "HipChatV2" do
                    :headers => {})
   end
 
+  def mock_successful_member(options={})
+    options = {:user_id => "1234"}.merge(options)
+    stub_request(:put, "https://api.hipchat.com/v2/room/Hipchat/member/#{options[:user_id]}").with(
+      :query => {:auth_token => "blah"},
+      :body  => {}.to_json,
+      :headers => {'Accept' => 'application/json',
+                   'Content-Type' => 'application/json'}).to_return(
+                   :status => 204,
+                   :body => "",
+                   :headers => {})
+  end
+
   def mock_successful_user_send(message)
     stub_request(:post, "https://api.hipchat.com/v2/user/12345678/message").with(
                                    :query   => {:auth_token => "blah"},

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -67,6 +67,15 @@ end
 
 shared_context "HipChatV2" do
   before { @api_version = 'v2'}
+  def mock_successful_send_message(message, options={})
+    options = {:color => 'yellow', :notify => false, :message_format => 'html'}.merge(options)
+    stub_request(:post, "https://api.hipchat.com/v2/room/Hipchat/message").with(
+                             :query => {:auth_token => "blah"},
+                             :body  => {:room_id => "Hipchat",
+                                        :message => "Hello world"}.to_json,
+                                        :headers => {'Accept' => 'application/json',
+                                                    'Content-Type' => 'application/json'}).to_return(:status => 200, :body => "", :headers => {})
+  end
   # Helper for mocking room message post requests
   def mock_successful_send(from, message, options={})
     options = {:color => 'yellow', :notify => false, :message_format => 'html'}.merge(options)

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -63,6 +63,17 @@ shared_context "HipChatV1" do
                                           :body => '{"room": {"room_id": "1234", "name" : "A Room"}}',
                                           :headers => {})
   end
+
+  def mock_successful_user_creation(name, email, options={})
+    stub_request(:post, "https://api.hipchat.com/v1/users/create").with(
+                             :query => {:auth_token => "blah"},
+                             :body  => { :name => "A User", :email => "email@example.com" }.merge(options),
+                             :headers => {'Accept' => 'application/json',
+                                          'Content-Type' => 'application/x-www-form-urlencoded'}).to_return(
+                                          :status => 200,
+                                          :body => '{"user": {"user_id": "1234", "A User" : "A User", "email" : "email@example.com"}}',
+                                          :headers => {})
+  end
 end
 
 shared_context "HipChatV2" do
@@ -165,6 +176,18 @@ shared_context "HipChatV2" do
                                           :body => '{"id": "12345", "links": {"self": "https://api.hipchat.com/v2/room/12345"}}',
                                           :headers => {})
   end
+
+  def mock_successful_user_creation(name, email, options={})
+    stub_request(:post, "https://api.hipchat.com/v2/user").with(
+                             :query => {:auth_token => "blah"},
+                             :body  => { :name => name, :email => email }.merge(options).to_json,
+                             :headers => {'Accept' => 'application/json',
+                                          'Content-Type' => 'application/json'}).to_return(
+                                          :status => 201,
+                                          :body => '{"id": "12345", "links": {"self": "https://api.hipchat.com/v2/user/12345"}}',
+                                          :headers => {})
+  end
+
 
   def mock_successful_get_room(room_id="1234")
     stub_request(:get, "https://api.hipchat.com/v2/room/#{room_id}").with(

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -197,11 +197,13 @@ shared_context "HipChatV2" do
                    :headers => {})
   end
 
-  def mock_successful_member(options={})
+  def mock_successful_add_member(options={})
     options = {:user_id => "1234"}.merge(options)
     stub_request(:put, "https://api.hipchat.com/v2/room/Hipchat/member/#{options[:user_id]}").with(
       :query => {:auth_token => "blah"},
-      :body  => {}.to_json,
+      :body  => {
+        :room_roles => options[:room_roles] || ["room_member"]
+      }.to_json,
       :headers => {'Accept' => 'application/json',
                    'Content-Type' => 'application/json'}).to_return(
                    :status => 204,


### PR DESCRIPTION
Add Room#add_member method which allows to add member to room.
https://www.hipchat.com/docs/apiv2/method/add_member

Add Room#send_message method which allows to send message to room (as authenticated user).
https://www.hipchat.com/docs/apiv2/method/send_message

Add Client#create_user method which allows to create user in group
https://www.hipchat.com/docs/api/method/users/create
https://www.hipchat.com/docs/apiv2/method/create_user