### PR TITLE
Pin web mock to 1.22.1 to avoid 'query' string bug

### DIFF
--- a/hipchat.gemspec
+++ b/hipchat.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rr"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", "= 1.22.1"
   spec.add_development_dependency 'rdoc', '> 2.4.2'
   spec.add_development_dependency 'coveralls'
 end


### PR DESCRIPTION
1.22.3 has a bug when using multiple stubs. Pinning the version of avoid hitting that.