### PR TITLE
Fix invalid api version, Issue #139

### DIFF
--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -20,10 +20,12 @@ module HipChat
           @base_uri = "#{options[:server_url]}/v1"
           @headers = {'Accept' => 'application/json',
              'Content-Type' => 'application/x-www-form-urlencoded'}
-        else
+        elsif @version.eql?('v2')
           @base_uri = "#{options[:server_url]}/v2"
           @headers = {'Accept' => 'application/json',
              'Content-Type' => 'application/json'}
+        else
+          raise InvalidApiVersion, 'Couldn\'t recognize API version'
         end
       end
 

--- a/spec/hipchat_spec.rb
+++ b/spec/hipchat_spec.rb
@@ -54,6 +54,11 @@ describe HipChat do
         client = HipChat::Client.new("blah", :api_version => 'v2')
         expect(client[:example].api_version).to eql('v2')
       end
+
+      it "when given '2' it raises an exception" do
+        expect { HipChat::Client.new("blah", :api_version => '2') }.
+          to raise_error(HipChat::InvalidApiVersion)
+      end
     end
 
     context "server_url" do


### PR DESCRIPTION
[Issue #139](https://github.com/hipchat/hipchat-rb/issues/139) fix. Raises the exception if incorrect api_version on Client initialzation.