### PR TITLE
Account for longer usernames allowed in v2 of hipchat

### DIFF
--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -129,8 +129,8 @@ module HipChat
     # +notify+:: true or false
     #            (default false)
     def send(from, message, options_or_notify = {})
-      if from.length > 15
-        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 15'"
+      if from.length > 20
+        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 20'"
       end
       options = if options_or_notify == true or options_or_notify == false
         warn 'DEPRECATED: Specify notify flag as an option (e.g., :notify => true)'
@@ -159,8 +159,8 @@ module HipChat
     end
 
     def share_link(from, message, link)
-      if from.length > 15
-        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 15'"
+      if from.length > 20
+        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 20'"
       end
 
       response = self.class.post(@api.share_link_config[:url],
@@ -185,8 +185,8 @@ module HipChat
     #   # Default
     #   send_file 'nickname', 'some message', File.open("/path/to/file")
     def send_file(from, message, file)
-      if from.length > 15
-        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 15'"
+      if from.length > 20
+        raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 20'"
       end
 
       response = self.class.post(@api.send_file_config[:url],


### PR DESCRIPTION
According to the description of your project, v2 is supported. I made these changes to be v2-compatible. To really be robust, though, you'd probably want to use some value that changes according to version number.

Let me know what you think.