### PR TITLE
updated user send syntax to match room send, add configurable message-format

### DIFF
--- a/lib/hipchat/user.rb
+++ b/lib/hipchat/user.rb
@@ -19,7 +19,10 @@ module HipChat
     #
     # Send a private message to user.
     #
-    def send(message, message_format='text', notify=false)
+    def send(message, options = {})
+      message_format = options[:message_format] ? options[:message_format] : 'text'
+      notify         = options[:notify]         ? options[:notify]         : false
+
       response = self.class.post(@api.send_config[:url],
                                  :query => { :auth_token => @token },
                                  :body => {


### PR DESCRIPTION
Apologies, on #168, I accidentally caused the syntaxes of the room send and direct send to diverge. This fixes that divergence.

before:
````ruby
hc.user(user).send(message, 'text', true)
````

after:
````ruby
hc.user(user).send(message, message_format: 'text', notify: true)
````
