### PR TITLE
Fixes 'warning: loading in progress, circular require considered harmful'

### DIFF
--- a/lib/hipchat/railtie.rb
+++ b/lib/hipchat/railtie.rb
@@ -1,5 +1,3 @@
-require 'hipchat'
-
 module HipChat
   class Railtie < Rails::Railtie
     rake_tasks do


### PR DESCRIPTION
Minimal steps to reproduce:

```
$ gem install rails
$ gem install hipchat
$ echo "require 'rails'" >> hipchat_test.rb
$ echo "require 'hipchat'" >> hipchat_test.rb
$ ruby -w hipchat_test.rb
... ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:120: warning: loading in progress, circular require considered harmful ...
```