### PR TITLE
Fix dependency issue that is breaking the Travis build

### DIFF
--- a/hipchat.gemspec
+++ b/hipchat.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock", "= 1.22.1"
+  spec.add_development_dependency "addressable", "= 2.4.0"
+  spec.add_development_dependency "json", "= 1.8.3"
   spec.add_development_dependency 'rdoc', '> 2.4.2'
   spec.add_development_dependency 'tins', '~> 1.6.0'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
Locking the versions of the addressable and json gems to the versions immediately before they stopped supporting Ruby 1.9.3.  

This seems like a maintenance problem; should hichat-rb drop Ruby 1.9 support instead?

The Travis build error:
> $ ruby --version
ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
...
$ bundle install --jobs=3 --retry=3
Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/.
Resolving dependencies...
public_suffix-2.0.4 requires ruby version >= 2.0, which is incompatible with the current version, ruby 1.9.3p551

For example: https://travis-ci.org/hipchat/hipchat-rb/jobs/177747406