### PR TITLE
Restrict term-ansicolor to a version that supports Ruby 1.9.3

### DIFF
--- a/hipchat.gemspec
+++ b/hipchat.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock", "= 1.22.1"
   spec.add_development_dependency "addressable", "= 2.4.0"
+  spec.add_development_dependency "term-ansicolor", "< 1.4.0"
   spec.add_development_dependency "json", "= 1.8.3"
   spec.add_development_dependency 'rdoc', '> 2.4.2'
   spec.add_development_dependency 'tins', '~> 1.6.0'


### PR DESCRIPTION
Update the gemspec to fix the following `bundle install` error in the 1.9.3 Travis build:
> term-ansicolor-1.4.0 requires ruby version >= 2.0, which is incompatible with the current version, ruby 1.9.3p551

Doing issue https://github.com/hipchat/hipchat-rb/issues/183 would be better! 