### PR TITLE
Add responses to exceptions!

### DIFF
--- a/lib/hipchat/errors.rb
+++ b/lib/hipchat/errors.rb
@@ -1,5 +1,21 @@
 module HipChat
-  class ServiceError            < StandardError;       end
+  class ServiceError < StandardError
+    attr_accessor :response
+
+    def initialize(msg, response: nil)
+      @response = response
+      @msg = msg
+    end
+
+    def message
+      if @response.present?
+        "#{@msg}:\nResponse: #{@response.body}"
+      else
+        @msg
+      end
+    end
+  end
+
   class RoomNameTooLong         < ServiceError;        end
   class RoomMissingOwnerUserId  < ServiceError;        end
   class UnknownResponseCode     < ServiceError;        end
@@ -24,24 +40,24 @@ module HipChat
     # @param response {HTTParty::Response} The HTTParty response/request object
     def self.response_code_to_exception_for(klass, identifier, response)
       # Supports user, room and webhook objects.  If we get something other than that, bail.
-      raise ServiceError "Unknown class #{klass}" unless [:user, :room, :webhook].include? klass
+      raise(ServiceError.new("Unknown class #{klass}", response: response)) unless [:user, :room, :webhook].include? klass
       # Grab the corresponding unknown object exception class and constantize it for the 404 case to call
       not_found_exception = Module.const_get(HipChat.to_s.to_sym).const_get("Unknown#{klass.capitalize}".to_sym)
       case response.code
         when 200, 201, 202, 204;
           return
         when 400
-          raise BadRequest, "The request was invalid. You may be missing a required argument or provided bad data. path:#{response.request.path.to_s} method:#{response.request.http_method.to_s}"
+          raise BadRequest.new("The request was invalid. You may be missing a required argument or provided bad data. path:#{response.request.path} method:#{response.request.http_method}", response: response)
         when 401, 403
-          raise Unauthorized, "Access denied to #{klass} `#{identifier}'"
+          raise Unauthorized.new("Access denied to #{klass} `#{identifier}'", response: response)
         when 404
-          raise not_found_exception,  "Unknown #{klass}: `#{identifier}'"
+          raise not_found_exception.new("Unknown #{klass}: `#{identifier}'", response: response)
         when 405
-          raise MethodNotAllowed, "You requested an invalid method. path:#{response.request.path.to_s} method:#{response.request.http_method.to_s}"
+          raise MethodNotAllowed.new("You requested an invalid method. path:#{response.request.path} method:#{response.request.http_method}", response: response)
         when 429
-          raise TooManyRequests, 'You have exceeded the rate limit. `https://www.hipchat.com/docs/apiv2/rate_limiting`'
+          raise TooManyRequests.new('You have exceeded the rate limit. `https://www.hipchat.com/docs/apiv2/rate_limiting`', response: response)
         else
-          raise UnknownResponseCode, "Unexpected #{response.code} for #{klass} `#{identifier}'"
+          raise UnknownResponseCode.new("Unexpected #{response.code} for #{klass} `#{identifier}'", response: response)
       end
     end
   end

--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -313,13 +313,13 @@ module HipChat
     # +name+::     The label for this webhook
     #                (default "")
     def create_webhook(url, event, options = {})
-      raise InvalidEvent unless %w(room_message room_notification room_exit room_enter room_topic_change room_archived room_deleted room_unarchived).include? event
+      raise InvalidEvent.new("Invalid event: #{event}") unless %w(room_message room_notification room_exit room_enter room_topic_change room_archived room_deleted room_unarchived).include? event
 
       begin
         u = URI::parse(url)
-        raise InvalidUrl unless %w(http https).include? u.scheme
+        raise InvalidUrl.new("Invalid Scheme: #{url}") unless %w(http https).include? u.scheme
       rescue URI::InvalidURIError
-        raise InvalidUrl
+        raise InvalidUrl.new("Invalid URL: #{url}")
       end
 
       merged_options = {


### PR DESCRIPTION
The `BadResponse` exception type is pretty much useless without explaining what went wrong—the provided message (`You may be missing a required argument or provided bad data`) is downright useless compared to the discarded response body, which actually helps provide an understanding of what is wrong with the request.

This pins a response to the exception, if there is a response to pin.