### PR TITLE
Added the reply endpoint

### DIFF
--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -186,6 +186,17 @@ module HipChat
         }[version]
       end
 
+      def reply_config
+        {
+            'v2' => {
+                :url => URI::escape("/#{room_id}/reply"),
+                :method => :post,
+                :query_params => { },
+                :body_format => :to_json
+            }
+        }[version]
+      end
+
       def send_file_config
         {
           'v2' => {

--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -96,12 +96,7 @@ module HipChat
     end
 
     def _rooms
-      response = self.class.get(@api.rooms_config[:url],
-        :query => {
-          :auth_token => @token
-        },
-        :headers => @api.headers
-      )
+      response = self.class.get(@api.rooms_config[:url], query: { auth_token: @token }, headers: @api.headers)
 
       ErrorHandler.response_code_to_exception_for :room, nil, response
       response[@api.rooms_config[:data_key]].map do |r|

--- a/lib/hipchat/room.rb
+++ b/lib/hipchat/room.rb
@@ -161,6 +161,16 @@ module HipChat
       true
     end
 
+    def reply(parent_message_id, message)
+      query_params  = { auth_token: @token }.merge(@api.reply_config[:query_params])
+      body          = { message: message, parent_message_id: parent_message_id }.send(@api.reply_config[:body_format])
+
+      response = self.class.post(@api.reply_config[:url], query: query_params, body: body, headers: @api.headers)
+
+      ErrorHandler.response_code_to_exception_for :room, 'all', response
+      response.parsed_response
+    end
+
     def share_link(from, message, link)
       if from.length > 20
         raise UsernameTooLong, "Username #{from} is `#{from.length} characters long. Limit is 20'"

--- a/lib/hipchat/user.rb
+++ b/lib/hipchat/user.rb
@@ -60,7 +60,7 @@ module HipChat
       )
 
       ErrorHandler.response_code_to_exception_for :user, user_id, response
-      User.new(@token, response.merge(:api_version => @api.version))
+      User.new(@token, response.merge(:api_version => @api.version, :server_url => server_url))
     end
 
     #

--- a/spec/hipchat_api_v2_spec.rb
+++ b/spec/hipchat_api_v2_spec.rb
@@ -29,7 +29,7 @@ describe "HipChat (API V2)" do
       expect(subject.rooms.first.history).to be_truthy
     end
 
-    it "fails when the room doen't exist" do
+    it "fails when the room doesn't exist" do
       allow(room.class).to receive(:get).with(anything, anything).and_return(OpenStruct.new(:code => 404))
 
       expect { room.history }.to raise_error(HipChat::UnknownRoom)
@@ -64,7 +64,7 @@ describe "HipChat (API V2)" do
       expect(subject.rooms.first.statistics).to be_truthy
     end
 
-    it "fails when the room doen't exist" do
+    it "fails when the room doesn't exist" do
       allow(room.class).to receive(:get).with(anything, anything).and_return(OpenStruct.new(:code => 404))
 
       expect { room.statistics }.to raise_error(HipChat::UnknownRoom)
@@ -202,6 +202,36 @@ describe "HipChat (API V2)" do
       allow(room.class).to receive(:post).with(anything, anything).and_return(OpenStruct.new(:code => 403))
 
       expect { room.send "", "" }.to raise_error(HipChat::Unauthorized)
+    end
+  end
+
+  describe '#reply' do
+    include_context 'HipChatV2'
+    let(:parent_id) { '100000' }
+    let(:message)   { 'Hello world' }
+
+    it 'successfully' do
+      mock_successful_reply parent_id, message
+
+      expect(room.reply(parent_id, message))
+    end
+
+    it "but fails when the parent_id doesn't exist" do
+      allow(room.class).to receive(:post).and_return(OpenStruct.new(:code => 404))
+
+      expect { room.reply parent_id, message }.to raise_error(HipChat::UnknownRoom)
+    end
+
+    it "but fails when we're not allowed to do so" do
+      allow(room.class).to receive(:post).and_return(OpenStruct.new(:code => 401))
+
+      expect { room.reply parent_id, message }.to raise_error(HipChat::Unauthorized)
+    end
+
+    it 'but fails if we get an unknown response code' do
+      allow(room.class).to receive(:post).and_return(OpenStruct.new(:code => 403))
+
+      expect { room.reply parent_id, message }.to raise_error(HipChat::Unauthorized)
     end
   end
 

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -123,6 +123,16 @@ shared_context "HipChatV2" do
                                                     'Content-Type' => 'application/json'}).to_return(:status => 200, :body => "", :headers => {})
   end
 
+  def mock_successful_reply(parent_message_id, message)
+    stub_request(:post, 'https://api.hipchat.com/v2/room/Hipchat/reply?auth_token=blah')
+        .with(query:  { auth_token:        'blah' },
+              body:   { parent_message_id: parent_message_id,
+                        message:           message },
+              headers:           { 'Accept':       'application/json',
+                                   'Content-Type': 'application/json' })
+        .to_return(status: 200, body: '', headers: {})
+  end
+
   def mock_successful_link_share(from, message, link)
     stub_request(:post, "https://api.hipchat.com/v2/room/Hipchat/share/link").with(
                              :query => {:auth_token => "blah"},

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -128,8 +128,8 @@ shared_context "HipChatV2" do
         .with(query:  { auth_token:        'blah' },
               body:   { parent_message_id: parent_message_id,
                         message:           message },
-              headers:           { 'Accept':       'application/json',
-                                   'Content-Type': 'application/json' })
+              headers:           { 'Accept' =>       'application/json',
+                                   'Content-Type' => 'application/json' })
         .to_return(status: 200, body: '', headers: {})
   end
 


### PR DESCRIPTION
We added the reply endpoint to our fork of the gem and thought it might be useful to get it back on the main branch here.

Changes:
- Added `Room#reply` endpoint.
- Updated ruby version to `2.4.1`.
- Slightly less implied interpolation with the double quotes.