### PR TITLE
Issue 199 - Added a method to return scopes for an auth token

### DIFF
--- a/lib/hipchat/api_version.rb
+++ b/lib/hipchat/api_version.rb
@@ -83,6 +83,15 @@ module HipChat
           }
         }[version]
       end
+
+      def scopes_config
+        raise InvalidApiVersion, 'This functionality is not supported in API v1' unless version.eql?('v2')
+        {
+          'v2' => {
+            :url => URI::escape("/oauth/token")
+          }
+        }[version]
+      end
     end
 
     class Room < ApiVersion
@@ -304,7 +313,7 @@ module HipChat
 
       def user_joined_rooms_config
         raise InvalidApiVersion, 'This functionality is not supported in API v1' unless version.eql?('v2')
-        
+
         {
           'v2' => {
             :url => URI::escape("/#{user_id}/preference/auto-join"),

--- a/lib/hipchat/client.rb
+++ b/lib/hipchat/client.rb
@@ -24,6 +24,43 @@ module HipChat
       HipChat::Room.new(@token, { room_id: name, :api_version => @api_version, :server_url => @options[:server_url] })
     end
 
+    # Returns the scopes for the Auth token
+    #
+    # Calls the endpoint:
+    #
+    #   https://api.hipchat.com/v2/oauth/token/#{token}
+    #
+    #   The response is a JSON object containing a client key. The client
+    #   object contains a list of allowed scopes.
+    #
+    #   There are two possible response types, for a global API token, the
+    #   room object will be nil. For a room API token, the room object will
+    #   be populated:
+    #
+    # Optional room parameter can be passed in. The method will return the
+    # following:
+    #
+    #   - if it's a global API token and room param is nil: scopes
+    #   - if it's a global API token and room param is not nil: scopes
+    #   - if it's a room API token and room param is nil: nil
+    #   - if it's a room API token and room param is not nil
+    #       - if room param's room_id matches token room_id: scopes
+    #       - if room param's room_id doesn't match token room_id: nil
+    #
+    # Raises errors if response is unrecognizable
+    def scopes(room: nil)
+      path = "#{@api.scopes_config[:url]}/#{URI::escape(@token)}"
+      response = self.class.get(path,
+        :query => { :auth_token => @token },
+        :headers => @api.headers
+      )
+      ErrorHandler.response_code_to_exception_for :room, 'scopes', response
+      return response['scopes'] unless response['client']['room']
+      if room && response['client']['room']['id'] == room.room_id
+        return response['scopes']
+      end
+    end
+
     def create_room(name, options={})
       if @api.version == 'v1' && options[:owner_user_id].nil?
         raise RoomMissingOwnerUserId, 'V1 API Requires owner_user_id'

--- a/spec/support/shared_contexts_for_hipchat.rb
+++ b/spec/support/shared_contexts_for_hipchat.rb
@@ -179,6 +179,29 @@ shared_context "HipChatV2" do
                                             :headers => {})
   end
 
+  def mock_successful_scopes(room: nil)
+    token_room = room ? { id: room.room_id, name: 'example' } : nil
+    stub_request(:get, 'https://api.hipchat.com/v2/oauth/token/blah').with(
+      :query => { :auth_token => 'blah' },
+      :body => '',
+      :headers => {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json'
+      }
+    ).to_return(
+      :status => 200,
+      :body => {
+        client: {
+          allowed_scopes: [:view_room, :send_notification],
+          name: 'All perms',
+          room: token_room
+        },
+        scopes: [:view_room, :send_notification]
+      }.to_json,
+      :headers => {}
+    )
+  end
+
   def mock_successful_history(options={})
     options = { :date => 'recent', :timezone => 'UTC', :format => 'JSON', :'max-results' => 100, :'start-index' => 0 }.merge(options)
     canned_response = File.new(HISTORY_JSON_PATH)


### PR DESCRIPTION
Added a method to the client class that returns scopes for an Auth token.
    
Calls the endpoint:

```    
https://api.hipchat.com/v2/oauth/token/#{token}
```
    
The response is a JSON object containing a client key. The client object contains a list of allowed scopes.
    
There are two possible response types, for a global API token, the room object will be nil:

```    
{
  "client": {
    "allowed_scopes": ["send_notification"],
    "name": "Testing",
    "room": null
  },
  "scopes": ["view_room", "send_notification"]
}
```
 
and for a room API token, the room object will be populated:

```
{
  "client": {
    "allowed_scopes": ["send_notification"],
    "name": "testang",
    "room": {
      "id": 123456789,
      "name": "example"
    }
  },
  "scopes": ["send_notification"]
}
```

Optional room parameter can be passed into the method.

```
def scopes(room: nil)
```

The method will return the following:
  
```  
- if it's a global API token and room param is nil: scopes
- if it's a global API token and room param is not nil: scopes
- if it's a room API token and room param is nil: nil
- if it's a room API token and room param is not nil
      - if room param's room_id matches token room_id: scopes
      - if room param's room_id doesn't match token room_id: nil
    
    Raises errors if response is unrecognizable
```